### PR TITLE
Otimizações e redução de algebrite

### DIFF
--- a/DomainColoring.js
+++ b/DomainColoring.js
@@ -35,7 +35,6 @@ function HSLtoRGB(h, s, l) {
 
 function getNumeroInteiro(){
     let numeroInteiro = (Math.floor((centro)/(qtdInteiros))); 
-    //Esses *100 faz com que o numero seja multiplo de 100
     return numeroInteiro;
 }
 
@@ -99,6 +98,21 @@ function Eixos (imgDataEixos, numeroInteiro){
     return imgDataEixos;
 }
 
+
+function getZvalue(x, y, resultado_real, resultado_imag){
+    let numeroInteiro = getNumeroInteiro();
+
+    let a = (x - centro)/numeroInteiro; //conversão de pixel para o plano.
+    let b = (y - centro)/numeroInteiro;
+    //f(z) -> z
+    
+    let real = eval(resultado_real);
+    let imag = eval(resultado_imag);
+
+    let z = [real, imag];
+    return z;
+}
+
 function Complexo_1(canvasElement, tipo_grafico,funcao,resultado_real,resultado_imag, tempoInicial)
 {
     
@@ -120,7 +134,6 @@ function Complexo_1(canvasElement, tipo_grafico,funcao,resultado_real,resultado_
 
     //let maxDist = Math.floor(Math.sqrt(centro * centro + centro * centro));
     numeroInteiro = getNumeroInteiro();
-    let maxDist = Math.floor(Math.sqrt(centro * centro + centro * centro));
     //console.log("maxdist:" + maxDist + " Centro: " + centro + " NumeroInt: " + numeroInteiro);
 
     
@@ -128,12 +141,16 @@ function Complexo_1(canvasElement, tipo_grafico,funcao,resultado_real,resultado_
         for (y = 0; y < height; y++){
             
             
-            let a = (x - centro)/numeroInteiro; //conversão de pixel para o plano.
-            let b = (y - centro)/numeroInteiro;
+            //let a = (x - centro)/numeroInteiro; //conversão de pixel para o plano.
+            //let b = (y - centro)/numeroInteiro;
             //f(z) -> z
             
-            let real = eval(resultado_real);
-            let imag = eval(resultado_imag);
+            //let real = eval(resultado_real);
+            //let imag = eval(resultado_imag);
+
+            let z = getZvalue(x, y, resultado_real, resultado_imag);
+            let real = z[0];
+            let imag = z[1];
             //f(z) -> z^3 - 1
             //let real = a*a*a - 3*a*b*b - 1;
             //let imag = 3*a*a*b - b*b*b;
@@ -213,13 +230,6 @@ function init(){
     let funcao = document.getElementById('funcao_complexa').value;
     let operacao = simplificarAntesAlgebrite(funcao);
 
-    //se houver uma letra que não seja Z (ou i), dá um alert de erro
-    //se houver um simbolo que não seja +, -, *, /, ^, dá um alert de erro
-    let regex = /[^z\^i\+\-\*\/\^\(\)\ \d\.]/gi;
-
-    if (regex.test(funcao) && false){
-        alert("Erro! Função inválida!");
-    }
     //remove todos os espaços de 'função'
     funcao = funcao.replace(/\s/g, '');
     //alert(funcao);
@@ -228,14 +238,7 @@ function init(){
     // (+, -, *, /, ^)
     //se houver, dar um alert de erro
 
-    regex = /z[^+\-\*\/\^]/gi;
-    if (regex.test(funcao) &&false)
-    {
-        alert("ERRO!");
-    } 
-    
-    else {
-        resultado = operacao;
+    resultado = operacao;
     console.log("Função final: " + resultado);
     let resultado_real = Algebrite.real(resultado).toString();
     let resultado_imag = Algebrite.imag(resultado).toString();
@@ -244,11 +247,11 @@ function init(){
     //Substitui ^ para vários * para que o eval possa entender
     resultado_real = simplificarExponencial(resultado_real);
     resultado_real = limparFuncao(resultado_real);
+    
     resultado_imag = limparFuncao(resultado_imag);
     resultado_imag = simplificarExponencial(resultado_imag);
     console.log("Parte real após o processamento: " + resultado_real);
     console.log("Parte imaginária após o processamento: " + resultado_imag);
     Complexo_1(canvasElement, tipo_grafico,resultado,resultado_real, resultado_imag, tempoInicial);
-    }
 }
 

--- a/DomainColoring.js
+++ b/DomainColoring.js
@@ -194,10 +194,10 @@ function init(){
     var tempoInicial = performance.now();
     let canvasElement = document.getElementById("domainColorCanvas");
 
-    let tamanho_grafico = document.getElementById('tamanho_grafico').value;
-    canvasElement.width = tamanho_grafico;
-    canvasElement.height = tamanho_grafico;
-    centro = tamanho_grafico/2;
+    //let tamanho_grafico = document.getElementById('tamanho_grafico').value;
+    //canvasElement.width = tamanho_grafico;
+    //canvasElement.height = tamanho_grafico;
+    centro = canvasElement.width/2;
     //Checa qual o checkbox selecionado (nome = 'tp_g')
     let tipo_grafico = document.querySelector('input[name="tp_g"]:checked').value;
     

--- a/DomainColoring.js
+++ b/DomainColoring.js
@@ -228,28 +228,30 @@ function init(){
 
     //Função:
     let funcao = document.getElementById('funcao_complexa').value;
-    let operacao = simplificarAntesAlgebrite(funcao);
+
 
     //remove todos os espaços de 'função'
-    funcao = funcao.replace(/\s/g, '');
+    //funcao = funcao.replace(/\s/g, '');
     //alert(funcao);
+    let operacao = simplificarAntesAlgebrite(funcao);
 
     //checar se, apos alguma letra Z, há um algarismo que não seja:
     // (+, -, *, /, ^)
     //se houver, dar um alert de erro
-
-    resultado = operacao;
+    const teste = iniciarGambiarra(operacao);
+    console.log ("Função inicial: " + teste[0]);
+    const resultado = teste[0];
+    const originais = teste[1];
     console.log("Função final: " + resultado);
-    let resultado_real = Algebrite.real(resultado).toString();
-    let resultado_imag = Algebrite.imag(resultado).toString();
+    let resultado_real = reverterGambiarra(Algebrite.real(resultado).toString(),originais);
+    let resultado_imag = reverterGambiarra(Algebrite.imag(resultado).toString(),originais);
+
     console.log("Parte real antes do processamento: " + resultado_real);
     console.log("Parte imaginária antes do processamento: " + resultado_imag);
     //Substitui ^ para vários * para que o eval possa entender
-    resultado_real = simplificarExponencial(resultado_real);
+
     resultado_real = limparFuncao(resultado_real);
-    
     resultado_imag = limparFuncao(resultado_imag);
-    resultado_imag = simplificarExponencial(resultado_imag);
     console.log("Parte real após o processamento: " + resultado_real);
     console.log("Parte imaginária após o processamento: " + resultado_imag);
     Complexo_1(canvasElement, tipo_grafico,resultado,resultado_real, resultado_imag, tempoInicial);

--- a/Funções_C.js
+++ b/Funções_C.js
@@ -1,6 +1,6 @@
 function simplificarExponencial(inputFunction) {
     //Transforma uma função em formato de a^b em Math.pow(a,b)
-    var outputFunction = inputFunction.replace(/(\w+)\s*\^\s*(\w+\.\w+)/g, function(match, base, exponent) {
+    var outputFunction = inputFunction.replace(/(\w+)\s*\^\s*(\w+(\.\w+)?)/g, function(match, base, exponent) {
         return 'Math.pow(' + base + ', ' + exponent + ')';
     });
 
@@ -33,7 +33,7 @@ function limparFuncao(funcaoOriginal) {
     funcaoLimpa = funcaoLimpa.replace(/\bcosh\(/g, 'Math.cosh(');
     funcaoLimpa = funcaoLimpa.replace(/\bsinh\(/g, 'Math.sinh(');
 
-    funcaoLimpa = funcaoLimpa.replace(/\((.*?)\)\^(\w+\.\w+)/g, 'Math.pow($1, $2)');
+    funcaoLimpa = funcaoLimpa.replace(/\((.*?)\)\^(\w+(\.\w+)?)/g, 'Math.pow($1, $2)');
 
     funcaoLimpa = funcaoLimpa.replace(/\babs\(/g, 'Math.abs(');
     funcaoLimpa = funcaoLimpa.replace(/\bexp\(/g, 'Math.exp(');

--- a/Funções_C.js
+++ b/Funções_C.js
@@ -1,25 +1,22 @@
 function simplificarExponencial(inputFunction) {
     //Transforma uma função em formato de a^b em Math.pow(a,b)
-
-    var outputFunction = inputFunction.replace(/(\w+)\s*\^\s*(\w+)/g, function(match, base, exponent) {
+    var outputFunction = inputFunction.replace(/(\w+)\s*\^\s*(\w+\.\w+)/g, function(match, base, exponent) {
         return 'Math.pow(' + base + ', ' + exponent + ')';
     });
 
     return outputFunction;
   }
 
-  function simplificarExpoenteImaginario(funcaoOriginal) {
-    // Um expoente no formato de i^1 = i^5 = i^9. Ou seja, i^x, onde x é um número inteiro, é sempre igual a i^x%4
-    // Além disso, o Algebrite não sabe fazer operações com i elevado a potências maiores que 5.
+function simplificarExpoenteImaginario(funcaoOriginal) {
+// Um expoente no formato de i^1 = i^5 = i^9. Ou seja, i^x, onde x é um número inteiro, é sempre igual a i^x%4
+// Além disso, o Algebrite não sabe fazer operações com i elevado a potências maiores que 5.
 
-    const regex = /(\bj\b)\^(\w+)/g;
-    const funcaoSimplificada = funcaoOriginal.replace(regex, function(match, base, expoente) {
-      return base + "^(" + eval(expoente + " % 4") + ")";
-    });
-    return funcaoSimplificada;
-  }
-
-
+const regex = /(\bj\b)\^(\w+)/g;
+const funcaoSimplificada = funcaoOriginal.replace(regex, function(match, base, expoente) {
+    return base + "^(" + eval(expoente + " % 4") + ")";
+});
+return funcaoSimplificada;
+}
 
 
 function limparFuncao(funcaoOriginal) {
@@ -35,10 +32,9 @@ function limparFuncao(funcaoOriginal) {
     funcaoLimpa = funcaoLimpa.replace(/\bsqrt\(/g, 'Math.sqrt(');
     funcaoLimpa = funcaoLimpa.replace(/\bcosh\(/g, 'Math.cosh(');
     funcaoLimpa = funcaoLimpa.replace(/\bsinh\(/g, 'Math.sinh(');
-    funcaoLimpa = funcaoLimpa.replace(/(\w+)\s*\^\s*\((.*?)\)/g, 'Math.pow($1, $2)');
-    funcaoLimpa = funcaoLimpa.replace(/\((.*?)\)\^(\w+)/g, 'Math.pow($1, $2)');
-    funcaoLimpa = funcaoLimpa.replace(/(\w+)\^(\w+)/g, 'Math.pow($1, $2)');
-    funcaoLimpa = funcaoLimpa.replace(/(.*?)\^(-?\d+(\.\d+)?)/g, 'Math.pow($1, $2)');
+
+    funcaoLimpa = funcaoLimpa.replace(/\((.*?)\)\^(\w+\.\w+)/g, 'Math.pow($1, $2)');
+
     funcaoLimpa = funcaoLimpa.replace(/\babs\(/g, 'Math.abs(');
     funcaoLimpa = funcaoLimpa.replace(/\bexp\(/g, 'Math.exp(');
     

--- a/Funções_C.js
+++ b/Funções_C.js
@@ -1,3 +1,56 @@
+function adicionar_real_imag(obj,real,imag) {
+    obj.real += real;
+    obj.imag += imag;
+    return obj;
+}
+
+   var caretReplace = function(_s) {
+    if (_s.indexOf("^") > -1) {
+        var tab = [];
+        var powfunc="Math.pow";
+        var joker = "___joker___";
+        while (_s.indexOf("(") > -1) {
+            _s = _s.replace(/(\([^\(\)]*\))/g, function(m, t) {
+                tab.push(t);
+                return (joker + (tab.length - 1));
+            });
+        }
+
+        tab.push(_s);
+        _s = joker + (tab.length - 1);
+        while (_s.indexOf(joker) > -1) {
+            _s = _s.replace(new RegExp(joker + "(\\d+)", "g"), function(m, d) {
+                return tab[d].replace(/(\w*)\^(\w*)/g, powfunc+"($1,$2)");
+            });
+        }
+    }
+    return _s;
+};
+
+function iniciarGambiarra(funcao) {
+    let cont = 0;
+    let originais = new Map();
+    let funcaoFinal = funcao;
+    funcaoFinal = funcaoFinal.replace(/\((.*?)\)\^\((.*?)\)/g, function (match) { 
+        cont++;
+        const substChar = String.fromCharCode(64 + cont);
+        originais.set(substChar, match);
+        return String.fromCharCode(64 + cont);
+    })
+    return [funcaoFinal, originais];    
+}
+
+function reverterGambiarra(funcao, original) {
+    let funcaoFinal = funcao;
+
+    funcaoFinal = funcaoFinal.replace(/[A-Z]/g, function(match) {
+        return original.get(match);
+    });
+
+    return funcaoFinal;
+}
+
+
 function simplificarExponencial(inputFunction) {
     //Transforma uma função em formato de a^b em Math.pow(a,b)
     var outputFunction = inputFunction.replace(/(\w+)\s*\^\s*(\w+(\.\w+)?)/g, function(match, base, exponent) {
@@ -20,26 +73,32 @@ return funcaoSimplificada;
 
 
 function limparFuncao(funcaoOriginal) {
-    var funcaoLimpa = funcaoOriginal.replace(/\basin\(/g, 'Math.asin(');
+
+
+    var funcaoLimpa = caretReplace(funcaoOriginal);
+    funcaoLimpa = funcaoLimpa.replace(/\basin\(/g, 'Math.asin(');
+    funcaoLimpa = funcaoLimpa.replace(/\bacos\(/g, 'Math.acos(');
+    funcaoLimpa = funcaoLimpa.replace(/\bcosh\(/g, 'Math.cosh(');
+    funcaoLimpa = funcaoLimpa.replace(/\bsinh\(/g, 'Math.sinh(');
+
     funcaoLimpa = funcaoLimpa.replace(/\bsin\(/g, 'Math.sin(');
     funcaoLimpa = funcaoLimpa.replace(/\bcos\(/g, 'Math.cos(');
+    
     funcaoLimpa = funcaoLimpa.replace(/\btan\(/g, 'Math.tan(');
-    funcaoLimpa = funcaoLimpa.replace(/\bacos\(/g, 'Math.acos(');
+    
     funcaoLimpa = funcaoLimpa.replace(/\batan\(/g, 'Math.atan(');
     funcaoLimpa = funcaoLimpa.replace(/\batan2\((.*?),(.*?)\)/g, 'Math.atan2($1, $2)');
     
     funcaoLimpa = funcaoLimpa.replace(/\blog\(/g, 'Math.log(');
     funcaoLimpa = funcaoLimpa.replace(/\bsqrt\(/g, 'Math.sqrt(');
-    funcaoLimpa = funcaoLimpa.replace(/\bcosh\(/g, 'Math.cosh(');
-    funcaoLimpa = funcaoLimpa.replace(/\bsinh\(/g, 'Math.sinh(');
-
-    funcaoLimpa = funcaoLimpa.replace(/\((.*?)\)\^(\w+(\.\w+)?)/g, 'Math.pow($1, $2)');
-
+    
     funcaoLimpa = funcaoLimpa.replace(/\babs\(/g, 'Math.abs(');
     funcaoLimpa = funcaoLimpa.replace(/\bexp\(/g, 'Math.exp(');
     
     return funcaoLimpa;
 }
+
+
 
 function espalhar_exp(funcao) {
     var outputString = funcao.replace(/(\w+)\^\((.*?)\)/g, function(match, base, exponents) {
@@ -52,7 +111,7 @@ function espalhar_exp(funcao) {
                 output += base + '^' + exponentArray[i] + ' * ';
             }
         }
-        return output.slice(0, -3); // Remove the trailing ' * '
+        return output.slice(0, -3); 
     });
     return outputString;
 }
@@ -76,15 +135,51 @@ function transformar_div(funcao) {
     return outputString;
 }
 
+
+function ar_comp_exp(expoente, operacao) {
+    return adicionar_real_imag(operacao,"cos(" + expoente + ")", "sin(" + expoente + ")");
+
+}
+
+function ar_comp_log (funcao, operacao)
+{
+    let real = Algebrite.real(funcao);
+    let imag = Algebrite.imag(funcao);
+    return adicionar_real_imag(operacao,"log( sqrt(" + real + "^2 + " + imag + "^2 ))", "atan2(" + imag + "," + real + ")");
+}
+
+function ar_comp_cos(funcao, operacao)
+{
+    let real = Algebrite.real(funcao);
+    let imag = Algebrite.imag(funcao);
+    return adicionar_real_imag(operacao,"cos(" + real + ")*cosh(" + imag + ")", "-sin(" + real + ")*sinh(" + imag + ")");
+}
+
+function ar_comp_sen(funcao, operacao)
+{
+    let real = Algebrite.real(funcao);
+    let imag = Algebrite.imag(funcao);
+    return adicionar_real_imag(operacao,"sin(" + real + ")*cosh(" + imag + ")", "cos(" + real + ")*sinh(" + imag + ")");
+}
+
+function ar_comp_pol(expoente, operacao)
+{
+    return adicionar_real_imag(operacao,"(a^2 + b^2)^(" + expoente/2 + ")*cos(" + expoente + "*atan2(b,a))", "(a^2 + b^2)^(" + expoente/2 + ")*sin(" + expoente + "*atan2(b,a))");
+}
+
 function comp_exp(expoente) {
     return "(cos(" + expoente + ") + i*sin(" + expoente + ") )";
+
+    //return "Math.cos(" + expoente + ") + i*Math.sin(" + expoente + ")";
 }
 
 function comp_log (funcao)
 {
     let real = Algebrite.real(funcao);
     let imag = Algebrite.imag(funcao);
-    return "(ln( sqrt(" + real + "^2 + " + imag + "^2 )) + i*atan2(" + imag + "," + real + "))";
+    return "(log( sqrt(" + real + "^2 + " + imag + "^2 )) + i*atan2(" + imag + "," + real + "))";
+
+    //return "(Math.log(Math.sqrt(" + real + "^2 + " + imag + "^2 )) + i*Math.atan2(" + imag + "," + real + "))";
 }
 
 function comp_sen(funcao)
@@ -92,6 +187,8 @@ function comp_sen(funcao)
     let real = Algebrite.real(funcao);
     let imag = Algebrite.imag(funcao);
     return "(sin(" + real + ")*cosh(" + imag + ") + i*cos(" + real + ")*sinh(" + imag + "))";
+
+    //return "(Math.sin(" + real + ")*Math.cosh(" + imag + ") + i*Math.cos(" + real + ")*Math.sinh(" + imag + "))";
 }
 
 function comp_cos(funcao)
@@ -100,13 +197,54 @@ function comp_cos(funcao)
     let real = Algebrite.real(funcao);
     let imag = Algebrite.imag(funcao);
     return "(cos(" + real + ")*cosh(" + imag + ") - i*sin(" + real + ")*sinh(" + imag + "))";
+
+    //return "(Math.cos(" + real + ")*Math.cosh(" + imag + ") - i*Math.sin(" + real + ")*Math.sinh(" + imag + "))";
 }
 function comp_pol(expoente)
 {
     return "(a^2 + b^2)^(" + expoente/2 + ")*(cos(" + expoente + "*atan2(b,a)) + i*sin(" + expoente + "*atan2(b,a)))";
+    //return "(Math.pow(Math.pow(a,2) + Math.pow(b,2)," + expoente/2 + ")*(Math.cos(" + expoente + "*Math.atan2(b,a)) + i*Math.sin(" + expoente + "*Math.atan2(b,a))))";
 }
 
 
+
+function ar_simplificarAntesAlgebrite(funcao, obj) {
+    let funcaoFinal = funcao;
+    let objFinal = obj;
+
+    funcaoFinal = funcaoFinal.replace(/z/g, '(a+b*i)');
+    funcaoFinal = espalhar_exp(funcaoFinal);
+    funcaoFinal = transformar_exp(funcaoFinal);
+    funcaoFinal = transformar_div(funcaoFinal);
+    
+    funcaoFinal = funcaoFinal.replace(/ln\((z|\(.*?\+.*?i\)|a\+b\*i)\)/g, (match, p1) => {
+        console.log("ai")
+        objFinal = ar_comp_log(`${p1}`, objFinal);
+        return comp_log(`${p1}`);
+    });
+    funcaoFinal = funcaoFinal.replace(/sen\((z|\(.*?\+.*?i\)|a\+b\*i)\)/g, (match, p1) => {
+        objFinal= ar_comp_sen(`${p1}`, objFinal);
+        return comp_sen(`${p1}`);
+    });
+    funcaoFinal = funcaoFinal.replace(/cos\((z|\(.*?\+.*?i\)|a\+b\*i)\)/g, (match, p1) => {
+        objFinal= ar_comp_cos(`${p1}`, objFinal);
+       return comp_cos(`${p1}`)
+    });
+    funcaoFinal = funcaoFinal.replace(/e\^\((.*?)\*i\)/g, (match, p1) => {
+        objFinal = ar_comp_exp(`${p1}`, objFinal);
+        return comp_cos(`${p1}`)
+    });
+    funcaoFinal = funcaoFinal.replace(/\((a\+b\*i)\)\^\((-?\w+)\)/g, (match, base, exponent) => {
+        objFinal = ar_comp_pol(`${exponent}`, objFinal);
+        return comp_pol(`${exponent}`);
+    });
+    funcaoFinal = funcaoFinal.replace(/\((a\+b\*i)\)\^(\w+)/g, (match, base, exponent) => {
+        objFinal = ar_comp_pol(`${exponent}`, objFinal);
+       return comp_pol(`${exponent}`); 
+    });
+    console.log(funcaoFinal);
+    return objFinal;
+}
 
 function simplificarAntesAlgebrite(funcao) {
     let funcaoFinal = funcao;
@@ -122,7 +260,6 @@ function simplificarAntesAlgebrite(funcao) {
     funcaoFinal = funcaoFinal.replace(/\((a\+b\*i)\)\^\((-?\w+)\)/g, (match, base, exponent) => comp_pol(`${exponent}`));
     funcaoFinal = funcaoFinal.replace(/\((a\+b\*i)\)\^(\w+)/g, (match, base, exponent) => comp_pol(`${exponent}`));
 
-
     return funcaoFinal;
 }
 
@@ -134,3 +271,15 @@ function simplificarPosAlgebrite(inputFunction)
 }
 
 
+var FERNANDO = function() {
+    Algebrite.save();
+    Algebrite.rect();
+    let p1 = Algebrite.pop();
+    Algebrite.push(p1);
+    Algebrite.push(p1);
+    Algebrite.conjugate();
+    Algebrite.add();
+    Algebrite.push_integer(2);
+    Algebrite.divide();
+    Algebrite.restore();
+};

--- a/index.css
+++ b/index.css
@@ -2,6 +2,7 @@
 
 :root{
     font-family: 'Jaldi', sans-serif;
+    font-size: 25px;
 }
 
 *{
@@ -49,6 +50,7 @@ section{
 .funcao{
     display: flex;
     flex-direction: column;
+    margin-bottom: 15px;
 }
 .funcao p{
     font-size: 1.2rem;
@@ -62,7 +64,7 @@ section{
     font-size: 1rem;
     font-weight: 100;
     color: rgb(82, 82, 82);
-    margin-bottom: 15px;
+    
 
 }
 
@@ -109,11 +111,22 @@ section{
     width: 100%;
 }
 
+.funcao h2{
+    font-size: 0.8rem;
+    font-weight: 100;
+    color: red;
+}
+
 #submit input:hover{
     background-color: rgb(82, 82, 82);
     color: white;
 }
 
+@media screen and (max-width: 1920px){
+    .container{
+        max-width: 1440px;
+    }  
+}
 @media screen and (max-width: 1440px){
     .container{
         max-width: 1024px;

--- a/index.css
+++ b/index.css
@@ -1,3 +1,14 @@
+@import url('https://fonts.googleapis.com/css2?family=Jaldi&display=swap');
+
+:root{
+    font-family: 'Jaldi', sans-serif;
+}
+
+*{
+    margin: 0;
+    padding: 0;
+}
+
 body {
     margin: 0;
     padding: 0;
@@ -8,30 +19,99 @@ body {
 canvas{
     border: 3px solid black;
     border-radius: 10px;
+    width: 100%;
+    aspect-ratio: 1;
 }
 
 section{
     width: 100%;
-    background-color: rgb(227, 255, 255);
     border-radius: 10px;
-    display: flex;
-    justify-content: space-around;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 50px;
 
 }
-section > *{
+section{
     margin-top: 30px;
 }
 
 #opcoes{
     padding: 15px;
-    background-color: rgb(216, 216, 255);
     border-radius: 10px;
     height: fit-content;
+    font-size: 1rem;
+}
+#opcoes > h1{
+    width: 100%;
+    text-align: center;
 }
 
-#submit > input{
-    margin: 10px 0px;
+.funcao{
+    display: flex;
+    flex-direction: column;
+}
+.funcao p{
+    font-size: 1.2rem;
+    font-weight: 100;
+    color: rgb(82, 82, 82);
+}
+.funcao input{
+    padding: 5px;
+    border-radius: 5px;
+    border: 1px solid rgb(82, 82, 82);
+    font-size: 1rem;
+    font-weight: 100;
+    color: rgb(82, 82, 82);
+    margin-bottom: 15px;
+
+}
+
+#options{
+    padding: 15px;
+    border: 1px solid rgb(82, 82, 82);
+    border-radius: 5px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+#options > .tipo{
+    display: flex;
+    align-items: center;
+    gap: 15px;
+}
+#options > .tipo > div{
+    display: flex;
+    gap: 3px;
+    padding: 3px 8px;
+    border-radius: 5px;
+}
+#options > .tipo > div.active{
+    background-color: rgb(181, 249, 181);
+}
+
+#options .funcao p{
+    font-size: 1rem !important;
+}
+#options .funcao input{
+    font-size: 0.8rem !important;
+}
+
+#submit input{
+    padding: 5px;
+    border-radius: 5px;
+    border: 1px solid rgb(82, 82, 82);
+    font-size: 1rem;
+    font-weight: 100;
+    color: rgb(82, 82, 82);
+    margin-top: 15px;
+    cursor: pointer;
+    transition: 0.3s;
     width: 100%;
+}
+
+#submit input:hover{
+    background-color: rgb(82, 82, 82);
+    color: white;
 }
 
 @media screen and (max-width: 1440px){
@@ -42,5 +122,17 @@ section > *{
 @media screen and (max-width: 1024px){
     .container{
         max-width: 768px;
+    }  
+}
+
+@media screen and (max-width: 768px){
+    .container{
+        max-width: 480px;
+    }  
+}
+
+@media screen and (max-width: 480px){
+    .container{
+        max-width: 320px;
     }  
 }

--- a/index.html
+++ b/index.html
@@ -11,42 +11,45 @@
 </head>
 <body onload="init()">
     <section class="container">
-        <div id="grafico">
-            <canvas id="domainColorCanvas" width="600" height="600"></canvas>
-        </div>
         <div id="opcoes">
             <h1>Funções complexas</h1>
             <form>
-                <div>
+                <div class="funcao">
                     <p>Função:  </p>
                     <input type="text" value="z" id="funcao_complexa"> 
                 </div>
-                <div>
-                    <p>Tipo do Gráfico: </p>
-                    <div style="display: flex;">
-                        <input type="radio" value="1" checked name="tp_g">
-                        <p>Continuo</p>
-                    </div>
-                    <div style="display: flex;">
-                        <input type="radio" value="2" name="tp_g">
-                        <p>Descontinuo</p> 
+                <div id="options">
+                    <div class="tipo">
+                        <p>Tipo do Gráfico: </p>
+                        <div class="active">
+                            <input type="radio" value="1" checked name="tp_g">
+                            <p>Continuo</p>
+                        </div>
+                        <div>
+                            <input type="radio" value="2" name="tp_g">
+                            <p>Descontinuo</p> 
+                        </div>
                     </div>
                     
-                    <div>
+                    <div class="funcao">
                         <p>Numero de inteiros: </p>
                         <input type="number" id="numero_inteiros" value="2" min="1" max="100">
                     </div>
 
-                    <div>
+                    <div class="funcao">
                         <p>Tamanho do gráfico:</p>
                         <input type="number" id="tamanho_grafico" value="500" min="100" max="4000" step="100">
                     </div>
-                    <div id="submit">
-                        <input type="button" value="Desenhar" onclick="init()">
-                    </div>
+                </div>
+                <div id="submit">
+                    <input type="button" value="Desenhar" onclick="init()">
                 </div>
             </form>
         </div>
+        <div id="grafico">
+            <canvas id="domainColorCanvas" width="600" height="600"></canvas>
+        </div>
+        
     </section>
     
 </body>

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <script src="algebritebundle.js"></script>
     <script src="Funções_C.js"></script>
     <script src="DomainColoring.js" ></script> 
+    <script src="index.js"></script>
     <title>F(Z) Números Complexos</title>  
 </head>
 <body onload="init()">
@@ -18,7 +19,7 @@
                     <p>Função:  </p>
                     <input type="text" value="z" id="funcao_complexa"> 
                 </div>
-                <div id="options">
+                <div id="options"> 
                     <div class="tipo">
                         <p>Tipo do Gráfico: </p>
                         <div class="active">

--- a/index.html
+++ b/index.html
@@ -11,6 +11,8 @@
     <title>F(Z) Números Complexos</title>  
 </head>
 <body onload="init()">
+    <script src="https://unpkg.com/mathjs/lib/browser/math.js"></script>
+
     <section class="container">
         <div id="opcoes">
             <h1>Funções complexas</h1>

--- a/index.html
+++ b/index.html
@@ -18,7 +18,9 @@
                 <div class="funcao">
                     <p>Função:  </p>
                     <input type="text" value="z" id="funcao_complexa"> 
+                    <h2 id="funcao-invalida" style="display: none;">Função invalida</h2>
                 </div>
+
                 <div id="options"> 
                     <div class="tipo">
                         <p>Tipo do Gráfico: </p>

--- a/index.js
+++ b/index.js
@@ -1,0 +1,15 @@
+function changeActiveClass() {
+    const radioDivs = document.querySelectorAll("#options .tipo div");
+    radioDivs.forEach(div => {
+        div.addEventListener("click", () => {
+            radioDivs.forEach(div => {
+                div.classList.remove("active");
+            });
+            div.classList.add("active");
+        });
+    });
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+    changeActiveClass();
+});

--- a/index.js
+++ b/index.js
@@ -10,6 +10,33 @@ function changeActiveClass() {
     });
 }
 
+function checaFuncao() {
+    const funcao = document.querySelector(".funcao > input").value;
+    const h2 = document.getElementById("funcao-invalida");
+    //checa se a função tem algum simbolo que não seja +, -, *, /, ^ PERMITE TODAS AS LETRAS E NUMEROS
+    const regex = /^[a-zA-Z0-9+*/^() \-]+$/;
+
+    
+    //bloqueia dois simbolos conseguitivos (ex: ++, --, *+, /-, ^/)
+    const regex2 = /[-+*/^]{2,}/;
+    //bloqueia simbolos no inicio e no fim da função (ex: +x, x+, -x, x-)
+    const regex3 = /^[*/^]|[-+*/^ ]$/;
+    
+    if (regex.test(funcao) && !regex2.test(funcao) && !regex3.test(funcao)) {
+        h2.style.display = "none";
+    }
+    else {
+        h2.style.display = "block";
+    }
+
+}
+
 document.addEventListener("DOMContentLoaded", () => {
     changeActiveClass();
+
+    const funcao = document.getElementById("funcao_complexa");
+    funcao.addEventListener("input", () =>
+    {
+        checaFuncao();
+    });
 });

--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
 function changeActiveClass() {
-    const radioDivs = document.querySelectorAll("#options .tipo div");
+    const radioDivs = document.querySelectorAll("#options .tipo div input");
     radioDivs.forEach(div => {
         div.addEventListener("click", () => {
             radioDivs.forEach(div => {
-                div.classList.remove("active");
+                div.parentElement.classList.remove("active");
             });
-            div.classList.add("active");
+            div.parentElement.classList.add("active");
         });
     });
 }


### PR DESCRIPTION
Esse texto, também, explica o que foi feito no commit passado.

A utilização do Algebrite mostrou uma diminuição considerável na performance, visto que ele realiza a expansão de polinômios, entre outras operações desnecessárias.

Nesses commits:
1. Foi removida a utilização do Algebrite.run para encontrar os valores (visto que ele não sabe lidar bem com números complexos)
2. Foi criada funções próprias para cálculo de funções complexas (comp_{sen,cos,log,exp,pol}
3. Criado método para ignorar as expansões de polinômios, ao substituir o polinômio por um caractere arbitrário.


TODO: 
- Tentar achar uma forma sem o algebrite de achar valores reais e imaginários
- cosh, senh, atan, tan
- Criar algoritmo próprio para multiplicação
- Executar algoritmo para operações repetidas (útil para z^z)
- Melhor alguns dos regexes para comp_exp e comp_pol